### PR TITLE
Create _mailing-create.scss

### DIFF
--- a/scss/civicrm/mailing/pages/_mailing-create.scss
+++ b/scss/civicrm/mailing/pages/_mailing-create.scss
@@ -1,0 +1,3 @@
+.crm-mosaico-page.ng-scope #inputSubject {
+  width:100% !important;
+}


### PR DESCRIPTION
Makes the subject line full width

## Overview
This makes the Subject field for new Mailings 100% of the container width.

## Before
It's too small!

## After
It's not too small.

## Technical Details
A new SCSS file
